### PR TITLE
Fix links

### DIFF
--- a/cli-files/README.md
+++ b/cli-files/README.md
@@ -32,7 +32,7 @@ for_you.txt
 rain.txt
 ```
 
-> 💡 See the [prep README.md](../prep/#command-line-examples) for an explanation of this command line example.
+> 💡 See the [prep README.md](../prep/README.md#command-line-examples) for an explanation of this command line example.
 
 While the `cat` command will output the contents of a file to you:
 

--- a/http-auth/README.md
+++ b/http-auth/README.md
@@ -57,7 +57,7 @@ Content-Type: text/plain; charset=utf-8
 Hello, world
 ```
 
-> 💡 See the [prep README.md](../prep/#command-line-examples) for an explanation of this command line example.
+> 💡 See the [prep README.md](../prep/README.md#command-line-examples) for an explanation of this command line example.
 
 A common [protocol](https://en.m.wikipedia.org/wiki/Communication_protocol) for sending data between clients and servers over the internet is HTTP. It's used for websites, for example.
 

--- a/multiple-servers/README.md
+++ b/multiple-servers/README.md
@@ -112,7 +112,7 @@ $ DATABASE_URL='postgres://localhost:5432/go-server-database' go run ./cmd/api-s
 $ go run ./cmd/static-server --path assets --port 8082
 ```
 
-> 💡 See the [prep README.md](../prep/#command-line-examples) for an explanation of this command line example.
+> 💡 See the [prep README.md](../prep/README.md#command-line-examples) for an explanation of this command line example.
 
 ### Static server
 

--- a/server-database/README.md
+++ b/server-database/README.md
@@ -58,7 +58,7 @@ Content-Length: 487
 [{"Title":"Sunset","AltText":"Clouds at sunset","URL":"https://images.unsplash.com/photo-1506815444479-bfdb1e96c566?ixlib=rb-1.2.1\u0026ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8\u0026auto=format\u0026fit=crop\u0026w=1000\u0026q=80"},{"Title":"Mountain","AltText":"A mountain at sunset","URL":"https://images.unsplash.com/photo-1540979388789-6cee28a1cdc9?ixlib=rb-1.2.1\u0026ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8\u0026auto=format\u0026fit=crop\u0026w=1000\u0026q=80"}]
 ```
 
-> 💡 See the [prep README.md](../prep/#command-line-examples) for an explanation of this command line example.
+> 💡 See the [prep README.md](../prep/README.md#command-line-examples) for an explanation of this command line example.
 
 We're going to need to import `"encoding/json"` and `Marshal` to turn the data into JSON.
 


### PR DESCRIPTION
Turns out the trailing / is a redirect which strips the fragment

-----
[View rendered cli-files/README.md](https://github.com/illicitonion/immersive-go-course/blob/fix-links/cli-files/README.md)
[View rendered http-auth/README.md](https://github.com/illicitonion/immersive-go-course/blob/fix-links/http-auth/README.md)
[View rendered multiple-servers/README.md](https://github.com/illicitonion/immersive-go-course/blob/fix-links/multiple-servers/README.md)
[View rendered server-database/README.md](https://github.com/illicitonion/immersive-go-course/blob/fix-links/server-database/README.md)