### PR TITLE
Remove references to impl branches in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ This course is structured into self-contained projects that you can work through
 
 Each project has its own directory with a README.md file that has instructions. If you want to take a look at one way of completing an exercise, there's some code waiting on a branch prefixed `impl/` (for "implementation") and an associated [Pull Request](https://github.com/CodeYourFuture/immersive-go-course/pulls) for you to look at. Try not to copy!
 
-1. [CLI & Files](./cli-files) — `impl/cat-ls`
+1. [CLI & Files](./cli-files)
    <br>An introduction to building things with Go by replicating the unix tools `cat` and `ls`.
-1. [Servers & HTTP requests](./http-auth) - `impl/http-auth`
+1. [Servers & HTTP requests](./http-auth)
    <br>Learn about long-running processes, HTTP and `curl`.
-1. [Servers & Databases](./server-database) - `impl/server-database`
+1. [Servers & Databases](./server-database)
    <br>Build a server that takes data from a database and serves it in `json` format.
-1. [Multiple Servers](./multiple-servers) - `impl/multiple-servers`
+1. [Multiple Servers](./multiple-servers)
    <br>Build and run file & API servers behind nginx in a simple multi-server architecture.
 1. [Docker & Cloud Deployment](./docker-cloud/)
    <br>Use containers to reproducibly deploy applications into the cloud


### PR DESCRIPTION
These were not adding anything to the README.


-----
[View rendered README.md](https://github.com/CodeYourFuture/immersive-go-course/blob/remove-impl-references/README.md)