### PR TITLE
Fix JS field names

### DIFF
--- a/multiple-servers/README.md
+++ b/multiple-servers/README.md
@@ -268,10 +268,10 @@ fetchImages(true).then(
 
     images.forEach((img) => {
       const imgElem$ = document.createElement("img");
-      imgElem$.src = img.URL;
-      imgElem$.alt = img.AltText;
+      imgElem$.src = img.url;
+      imgElem$.alt = img.alt_text;
       const titleElem$ = document.createElement("h3");
-      titleElem$.textContent = img.Title;
+      titleElem$.textContent = img.title;
       const wrapperElem$ = document.createElement("div");
       wrapperElem$.classList.add("gallery-image");
       wrapperElem$.appendChild(titleElem$);


### PR DESCRIPTION
The `curl` examples in the README suggest these field names, let's be consistent so that the JS and Go actually talk to each other if built to spec.

-----
[View rendered multiple-servers/README.md](https://github.com/illicitonion/immersive-go-course/blob/fix-js-field-names/multiple-servers/README.md)