### PR TITLE
Prep README.md revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An immersive, introductory course to backend software engineering using [go](htt
 
 ## Requirements
 
-Before you start this course, make sure you've followed all of the instructions in the [prep](prep/README.md) section.
+Before you start this course, make sure you've read and followed all of the instructions in the [prep](prep/README.md) document. This will get you set up and explain how to work through the projects.
 
 Remember: you can _always_ Google or ask for help if you get stuck.
 
@@ -14,7 +14,7 @@ Remember: you can _always_ Google or ask for help if you get stuck.
 
 This course is structured into self-contained projects that you can work through at your own pace.
 
-Each project has its own directory with a README.md file that has instructions. If you want to take a look at one way of completing an exercise, there's some code waiting on a branch prefixed `impl/` (for "implementation") and an associated [Pull Request](https://github.com/CodeYourFuture/immersive-go-course/pulls) for you to look at. Try not to copy!
+Each project has its own directory with a README.md file that has instructions. If you want to take a look at one way of completing an exercise, there's some code waiting on a branch prefixed `impl/` (short for "implementation") and an associated [Pull Request](https://github.com/CodeYourFuture/immersive-go-course/pulls) for you to look at. Try not to copy!
 
 1. [CLI & Files](./cli-files)
    <br>An introduction to building things with Go by replicating the unix tools `cat` and `ls`.

--- a/prep/README.md
+++ b/prep/README.md
@@ -112,6 +112,16 @@ To work on the projects:
 - For each project, open a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) against your own fork with your implementation of the project. Don't put code for different projects into the same PR!
 - Remember to make [small, incremental commits](https://dustinspecker.com/posts/making-smaller-git-commits/) and to only include code for a _single_ project in each commit
 
+In general, work through each project like this:
+
+1. Make it **work**
+1. Make it **right**
+1. Optional: Make it **pretty** (or fast)
+
+Making it "right" means ensuring the structure is clear, reasonably simple, and documented, with error handling and tests in place. But it does't mean perfect!
+
+In other words, resist the temptation to optimise or refactor individual pieces of the project, for example to use fancy techniques like go-routines and channels, until you have project working end-to-end. Sometimes it's only when you have the whole working project in front of you that you can see how the individual pieces should _really_ work, and optimising too early can waste time.
+
 ### Opening the right directory
 
 When writing Go in VS Code, many of the helper features only work if you opened the folder directly containing the file named `go.mod`.

--- a/prep/README.md
+++ b/prep/README.md
@@ -8,7 +8,7 @@ Before you start this course, there's a few things we assume you've done:
 - You have experience with JavaScript in the browser and in [Node](https://nodejs.org/en/)
 - You've completed the [Tour of Go](https://go.dev/tour/welcome/1)
 
-This is important because we don't cover the basic language features of Go: you need to be familiar with writing Go functions and methods, plus the basics of types in Go. You'll also need to to navigate [packages and documentation](https://pkg.go.dev/).
+This is important because we don't cover the basic language features of Go: you need to be familiar with writing Go functions and methods, plus the basics of types in Go. You'll also need to know how to navigate [packages and documentation](https://pkg.go.dev/).
 
 Remember: you can _always_ Google or ask for help if you get stuck.
 

--- a/prep/README.md
+++ b/prep/README.md
@@ -8,17 +8,17 @@ Before you start this course, there's a few things we assume you've done:
 - You have experience with JavaScript in the browser and in [Node](https://nodejs.org/en/)
 - You've completed the [Tour of Go](https://go.dev/tour/welcome/1)
 
-This is important because we don't cover the basic language features of Go: you need to be familiar with writing Go functions and methods, plus the basics of types in Go. You'll also need to know how to navigate [packages and documentation](https://pkg.go.dev/).
+This is important because we don't cover the basic language features of Go: you need to be familiar with writing Go functions and methods, plus the basics of types in Go. You'll also need to know how to navigate [packages and documentation](https://pkg.go.dev/), and we have a [short guide on how to do that](#learn-how-to-navigate-go-documentation).
 
 Remember: you can _always_ Google or ask for help if you get stuck.
 
 ## Set up and get to know your IDE
 
-We're going to assume you're using VS Code in this course.
+We're going to assume you're using [Visual Studio Code](https://code.visualstudio.com/) in this course.
 
-With Code Your Future so far, you've mostly used VS Code just as a text editor. It can also be a lot more powerful than that, but in order to do so, it needs to know details of the language you're writing. Set up the Go extension for VS Code by following [these instructions](https://code.visualstudio.com/docs/languages/go).
+VS Code is a lot more powerful that a simple text editor: it can help you write code, spot mistakes, and help you fix them. But it needs to know details of the programming language, so we need to install an extension to support go.
 
-Have a read of the features listed on that page.
+Set up the Go extension for VS Code by following [these instructions](https://code.visualstudio.com/docs/languages/go). Have a read of the features listed on that page.
 
 Some of the really useful ones:
 
@@ -27,14 +27,6 @@ Some of the really useful ones:
 3. Autocomplete - Go can guess what you're about to type, and save you time. But more importantly, it can tell you what exists - if you're looking to use something related to HTTP, and you think it's probably in the `http` package, you can type `http.` and see what's auto-completed for you - that could help you find the code you want without needing to switch to Google.
 
 Write a bit of Go in VS Code and experiment with these features. A small investment now will save a lot of time in the future!
-
-> :warning: **Opening the right directory** - When writing Go in VS Code, many of these features only work if you opened the folder directly containing the file named `go.mod`.
->
-> When working in `immersive-go-course`, you need to open a new window in the directory the code you're working on lives in.
->
-> If you opened VS Code in the root directory of `immersive-go-course`, you'll probably see a lot of red squiggly lines in your Go code and errors starting "could not import".
->
-> You can have more than one copy of VS Code open at a time if you need to.
 
 ## Learn how to navigate Go documentation
 
@@ -110,3 +102,22 @@ goodbye
 ```
 
 Generally each time a line starts with a `>`, it's a new command (but _occasionally_ it may be output from a previous one!)
+
+## Working on the projects
+
+To work on the projects:
+
+- [Fork this repository](https://github.com/CodeYourFuture/immersive-go-course/fork) — this [creates your own copy](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+- Work through [the projects in order](../README.md) — they are designed to conceptually build on each other and increase in complexity
+- For each project, open a pull request against your own fork with your implementation of the project
+- Remember to make [small, incremental commits](https://dustinspecker.com/posts/making-smaller-git-commits/) and to only include code for a _single_ project in each commit
+
+### Opening the right directory
+
+When writing Go in VS Code, many of the helper features only work if you opened the folder directly containing the file named `go.mod`.
+
+So when working in `immersive-go-course`, you _need to open a new window for project directory with the code you're working on_.
+
+If you opened VS Code in the main ("root") directory of `immersive-go-course`, you'll probably see a lot of red squiggly lines in your Go code and errors starting "could not import".
+
+You can have more than one copy of VS Code open at a time if you need to.

--- a/prep/README.md
+++ b/prep/README.md
@@ -109,7 +109,7 @@ To work on the projects:
 
 - [Fork this repository](https://github.com/CodeYourFuture/immersive-go-course/fork) — this [creates your own copy](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
 - Work through [the projects in order](../README.md) — they are designed to conceptually build on each other and increase in complexity
-- For each project, open a pull request against your own fork with your implementation of the project
+- For each project, open a [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) against your own fork with your implementation of the project. Don't put code for different projects into the same PR!
 - Remember to make [small, incremental commits](https://dustinspecker.com/posts/making-smaller-git-commits/) and to only include code for a _single_ project in each commit
 
 ### Opening the right directory

--- a/prep/README.md
+++ b/prep/README.md
@@ -5,8 +5,8 @@
 Before you start this course, there's a few things we assume you've done:
 
 - You're familiar with the essentials of writing code in JavaScript
-- You have experience with JavaScript in the browser and in [Node][node]
-- You've completed the [Tour of Go][tourofgo]
+- You have experience with JavaScript in the browser and in [Node](https://nodejs.org/en/)
+- You've completed the [Tour of Go](https://go.dev/tour/welcome/1)
 
 This is important because we don't cover the basic language features of Go: you need to be familiar with writing Go functions and methods, plus the basics of types in Go. You'll also need to to navigate [packages and documentation](https://pkg.go.dev/).
 


### PR DESCRIPTION
- Fix prep links to Node and Tour of Go
- Fix spelling/grammar issues
- Reorganise and document writing small commits, and independent PRs

Fix #42

-----
[View rendered prep/README.md](https://github.com/CodeYourFuture/immersive-go-course/blob/prep-links-fix/prep/README.md)