### PR TITLE
Add funding.yml for Github Sponsors

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,2 @@
+github: [CodeYourFuture]
+custom: ["https://codeyourfuture.io/donate/"]


### PR DESCRIPTION
CYF has a Github Sponsors account
To make the button show up we need this:

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository