### PR TITLE
Don't show toc outline if no pages to show

### DIFF
--- a/website/layouts/_default/list.html
+++ b/website/layouts/_default/list.html
@@ -5,6 +5,7 @@
   <div class="c-page-header__container">
     <h1 class="c-page-header__title e-heading e-heading__1">{{.Title}}</h1>
 
+    {{ if .Pages }}
     <aside class="c-toc c-page-header__toc is-none--lt-container">
       <ol>
         {{ range .Pages }}
@@ -14,6 +15,7 @@
         {{ end}}
       </ol>
     </aside>
+    {{ end }}
   </div>
 </header>
 


### PR DESCRIPTION
Otherwise we get a weird blue box displayed on pages with no .Pages.