### PR TITLE
Remove dotted underline style on links

### DIFF
--- a/website/assets/styles/03-elements/links.scss
+++ b/website/assets/styles/03-elements/links.scss
@@ -9,7 +9,7 @@ a:link:not([class]),
 a:visited:not([class]),
 .e-link {
   color: currentColor;
-  text-decoration: dotted underline;
+  text-decoration: underline;
 
   @include on-event {
     text-decoration: underline;

--- a/website/assets/styles/03-elements/links.scss
+++ b/website/assets/styles/03-elements/links.scss
@@ -10,6 +10,7 @@ a:visited:not([class]),
 .e-link {
   color: currentColor;
   text-decoration: underline;
+  text-decoration-style: dotted;
 
   @include on-event {
     text-decoration: underline;


### PR DESCRIPTION
Apparently Safari doesn't support dotted at all, which means that these don't look like links on any iOS browsers or on desktop Safari.