### PR TITLE
fix: relative link to prep section README

### DIFF
--- a/projects/cli-files/README.md
+++ b/projects/cli-files/README.md
@@ -36,7 +36,7 @@ for_you.txt
 rain.txt
 ```
 
-> 💡 See the [prep README.md](../prep/README.md#command-line-examples) for an explanation of this command line example.
+> 💡 See the [prep README.md](../../prep/README.md#command-line-examples) for an explanation of this command line example.
 
 While the `cat` command will output the contents of a file to you:
 


### PR DESCRIPTION
Hi @illicitonion!

Came across this while going through the building CLI-sections and I think you almost certainly intended to route to the prep section README file. Apologies for taking the liberty of directly raising a PR - I thought it would be faster!
