### PR TITLE
i would like to reorder the primers into folders

### DIFF
--- a/website/build.sh
+++ b/website/build.sh
@@ -49,6 +49,20 @@ for file in $(find website/content/projects -name README.md); do
   mv "${file}" "${file%README.md}index.md"
 done
 
+# Rename README.md based on directory structure within primers so we can have bundles and images stay working
+find website/content/primers -type d | while read -r dir; do
+  if [[ -f "${dir}/README.md" ]]; then
+    # Check if the directory has subdirectories
+    if find "${dir}" -mindepth 1 -type d | read; then
+      # If it has subdirectories, rename README.md to _index.md
+      mv "${dir}/README.md" "${dir}/_index.md"
+    else
+      # If it does not have subdirectories, rename README.md to index.md
+      mv "${dir}/README.md" "${dir}/index.md"
+    fi
+  fi
+done
+
 find website/content -name '*.md' -print0 | xargs -0 "${sed_i[@]}" -e '/^<!--forhugo$/d' -e '/^forhugo-->$/d'
 
 cd website


### PR DESCRIPTION
this will make image handling easier and less fragile as you can store the image in the folder with the readme and it won't break when copied over to hugo

my bash scripting is horrible so please improve if you can

I have some copy edits on primers that are dependent on this change
