### PR TITLE
workbook 08 - fix memcached clusters project link

### DIFF
--- a/website/content/workbooks/workbook-8.md
+++ b/website/content/workbooks/workbook-8.md
@@ -17,7 +17,7 @@ weight=3
 
 - [ ] [Batch processing](../../projects/batch-processing)
 - [ ] [Buggy app](../../projects/buggy-app)
-- [ ] [Memcache](../../projects/memcache)
+- [ ] [Memcached Clusters](../../projects/memcached-clusters)
 - [ ] [Troubleshooting project #2](https://docs.google.com/document/d/1V6HEu_OcJ3MHH-aHzUfANf06VJa1rPcGHcpBwql7QLA/edit#heading=h.cjnguaxmynan) TOADD
 
 ## Product


### PR DESCRIPTION
In workbook 08 the "**Memcache**" project has a broken link

**Renamed** the project to "**Memcached Clusters**" 
And **updated the link** to correctly point to `/projects/memcached-clusters/README.md` 

## Before:
![image](https://github.com/CodeYourFuture/immersive-go-course/assets/61154071/2e08579f-3f5f-4f0b-adfc-25c693c0fe81)


## After:
![image](https://github.com/CodeYourFuture/immersive-go-course/assets/61154071/d3fa7d1b-dfc2-414a-a1b9-bf9b0693cf30)
![image](https://github.com/CodeYourFuture/immersive-go-course/assets/61154071/89e1de36-3a51-4d36-8666-ba2a5e9fece8)
