### PR TITLE
memcached clusters project - docker-compose fix (for apple silicon)

### DIFF
--- a/projects/memcached-clusters/replicated/docker-compose.yml
+++ b/projects/memcached-clusters/replicated/docker-compose.yml
@@ -14,6 +14,7 @@ services:
         - 11214:11211
   mcrouter:
     image: docker-registry.wikimedia.org/mcrouter:latest
+    platform: linux/amd64
     links:
         - memcached1:memcached1
         - memcached2:memcached2

--- a/projects/memcached-clusters/sharded/docker-compose.yml
+++ b/projects/memcached-clusters/sharded/docker-compose.yml
@@ -10,6 +10,7 @@ services:
         - 11213:11211
   mcrouter:
     image: docker-registry.wikimedia.org/mcrouter:latest
+    platform: linux/amd64
     links:
         - memcached1:memcached1
         - memcached2:memcached2


### PR DESCRIPTION
## Problem

currently if you try to start this project on Apple Silicon M~ ARM Architecture

when you run` docker compose up -d` on both `replicated` and `sharded` from the readme instructions, 
you will get an error:

```
baz@bazs-MacBook-Pro replicated % docker compose up -d
[+] Running 6/6
 ✔ Network replicated_default                                                                                                                              Created                                                     0.0s 
 ✔ Container replicated-memcached1-1                                                                                                                       Started                                                     0.0s 
 ✔ Container replicated-memcached3-1                                                                                                                       Started                                                     0.0s 
 ✔ Container replicated-memcached2-1                                                                                                                       Started                                                     0.0s 
 ✔ Container replicated-mcrouter-1                                                                                                                         Started                                                     0.0s 
 ! mcrouter The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                                                             0.0s 
baz@bazs-MacBook-Pro replicated %  
```

Because the image being pulled is for `linux/amd64` but the Apple Silicon is `linux/arm64/v8`

However that registry does not have a `linux/arm64/v8` image, as can be seen:

```
baz@bazs-MacBook-Pro replicated % docker compose up -d
[+] Running 0/1
 ⠼ mcrouter Pulling                                                                                                                             0.4s 
image with reference docker-registry.wikimedia.org/mcrouter:latest was found but does not match the specified platform: wanted linux/arm64/v8, actual: linux/amd64
baz@bazs-MacBook-Pro replicated % 
```

## Solution

So instead we explicility specify the `platform` under the `mcrouter` `service` in both `docker-compose.yml`

```yml
  mcrouter:
    image: docker-registry.wikimedia.org/mcrouter:latest
    platform: linux/amd64
```

And now try again...

```sh
baz@bazs-MacBook-Pro replicated % docker compose up -d
[+] Running 5/5
 ✔ Network replicated_default         Created                                                                                                   0.0s 
 ✔ Container replicated-memcached1-1  Started                                                                                                   0.0s 
 ✔ Container replicated-memcached2-1  Started                                                                                                   0.0s 
 ✔ Container replicated-memcached3-1  Started                                                                                                   0.0s 
 ✔ Container replicated-mcrouter-1    Started                                                                                                   0.0s 
baz@bazs-MacBook-Pro replicated % 
```

Success