### PR TITLE
memcached clusters - replicated - mcrouter config fix

### DIFF
--- a/projects/memcached-clusters/replicated/docker-compose.yml
+++ b/projects/memcached-clusters/replicated/docker-compose.yml
@@ -19,6 +19,6 @@ services:
         - memcached1:memcached1
         - memcached2:memcached2
         - memcached3:memcached3
-    command: mcrouter --config-str='{"pools":{"A":{"servers":["memcached1:11211", "memcached2:11211", "memcached3:11211"]}},"route":{"type":"OperationSelectorRoute","operation_policies":{"add":"AllFastestRoute|Pool|A","delete":"AllFastestRoute|Pool|A","get":"AllFastestRoute|Pool|A","set":"AllFastestRoute|Pool|A"}}}' -p 11211
+    command: mcrouter --config-str='{"pools":{"A":{"servers":["memcached1:11211", "memcached2:11211", "memcached3:11211"]}},"route":{"type":"OperationSelectorRoute","operation_policies":{"add":"AllFastestRoute|Pool|A","delete":"AllFastestRoute|Pool|A","get":"AllFastestRoute|Pool|A","gets":"AllFastestRoute|Pool|A","set":"AllFastestRoute|Pool|A"}}}' -p 11211
     ports:
         - 11211:11211


### PR DESCRIPTION
the [gomemcache](https://github.com/bradfitz/gomemcache) Go client recommended in the project readme has a method called [`Get()`](https://pkg.go.dev/github.com/bradfitz/gomemcache/memcache#Client.Get)

but (**_non-intuitively_**) it sends the `memcached` protocol command `gets` (instead of `get`)

see that line here:
https://github.com/bradfitz/gomemcache/blob/24af94b0387418c51cc45a2e1fe6d4d1bef8a0fd/memcache/memcache.go#L383

[there is controversy on the github repo around this, and i personally **_did not find this naming choice intuitive at all_**]

Note: `gets` expects a CAS ID Token and `get` does not

Therefore whilst doing the project as instructed...

I was simply unable to make a successful `Get()` on the `replicated` instances 
because in the `replicated/docker-compose.yml` the `mcrouter` config is this (a squashed version of):

```json
{
  "pools": {
    "A": {
      "servers": ["memcached1:11211", "memcached2:11211", "memcached3:11211"]
    }
  },
  "route": {
    "type": "OperationSelectorRoute",
    "operation_policies": {
      "add": "AllFastestRoute|Pool|A",
      "delete": "AllFastestRoute|Pool|A",
      "get": "AllFastestRoute|Pool|A",
      "set": "AllFastestRoute|Pool|A"
    }
  }
}
```

If you tried to make a `Get()` you would get this error:
```
memcache: unexpected line in get response: "SERVER_ERROR unexpected result mc_res_unknown (0) for get\r\n"
```

I spent a lot of time trying to dig and debug to arrive at this conclusion and resolve this

In order for the `replicated` instances to receive a `gets` command from the `gomemcache` Go client the `mcrouter` config needs to be updated to have an `operation_policies` for `gets`

```json
{
  "pools": {
    "A": {
      "servers": ["memcached1:11211", "memcached2:11211", "memcached3:11211"]
    }
  },
  "route": {
    "type": "OperationSelectorRoute",
    "operation_policies": {
      "add": "AllFastestRoute|Pool|A",
      "delete": "AllFastestRoute|Pool|A",
      "get": "AllFastestRoute|Pool|A",
      "gets": "AllFastestRoute|Pool|A", <-- added
      "set": "AllFastestRoute|Pool|A"
    }
  }
}
```

And after that the gomemcaache `Get()` method sends the `gets` to the `replicated` instances which can now respond to them as they have that policy