### PR TITLE
Split up work by topic not task

### DIFF
--- a/website/content/workbooks/workbook-10.md
+++ b/website/content/workbooks/workbook-10.md
@@ -7,14 +7,14 @@ weight=5
 
 # Provisional start date: 20 May 2024
 
-## Study
+## Asynchronous work and pipelines
 
-- [ ] [Distributed Systems: Asynchronous Work and Pipelines](../../primers/distributed-software-systems-architecture/asynchronous-work-and-pipelines)
+- [ ] Read about [Distributed Systems: Asynchronous Work and Pipelines](../../primers/distributed-software-systems-architecture/asynchronous-work-and-pipelines)
+- [ ] Project: [Kafka Cron](../../projects/kafka-cron) - Distributed Cron system with Prometheus monitoring
+
+## Troubleshooting
+
 - [ ] [Troubleshooting Primer](../../primers/troubleshooting/)
-
-## Projects
-
-- [ ] [Kafka Cron](https://github.com/CodeYourFuture/immersive-go-course/tree/main/kafka-cron) - Distributed Cron system with Prometheus monitoring
 - [ ] [Troubleshooting project #4](https://docs.google.com/document/d/1V6HEu_OcJ3MHH-aHzUfANf06VJa1rPcGHcpBwql7QLA/edit#heading=h.cjnguaxmynan) TOADD
 
 ## Product

--- a/website/content/workbooks/workbook-11.md
+++ b/website/content/workbooks/workbook-11.md
@@ -7,15 +7,18 @@ weight=6
 
 # Provisional start date: 3 June 2024
 
-## Study
+## Distributed Locking and Distributed Consensus
 
-- [ ] [Distributed Systems: Asynchronous Work and Pipelines](../../primers/distributed-software-systems-architecture/distributed-locking-and-distributed-consensus/)
-- [ ] [Troubleshooting Primer](../../primers/troubleshooting/)
+- [ ] Read about [Distributed Systems: Distributed Locking and Distributed Consensus](../../primers/distributed-software-systems-architecture/distributed-locking-and-distributed-consensus/)
+- [ ] Do [the RAFT OTEL project](../../projects/raft-otel). This large project explores a distributed consensus protocol using distributed tracing.
 
-## Projects
+## Datastores
 
-- [ ] [RAFT OTEL](../../projects/raft-otel) Do the raft-otel project. This large project explores a distributed consensus protocol using distributed tracing.
 - [ ] [DataStores]() TODO: Add datastores project
+
+## Troubleshooting
+
+- [ ] [Troubleshooting Primer](../../primers/troubleshooting/)
 - [ ] [Troubleshooting project #3](https://docs.google.com/document/d/1V6HEu_OcJ3MHH-aHzUfANf06VJa1rPcGHcpBwql7QLA/edit#heading=h.cjnguaxmynan) TOADD
 
 ## Product

--- a/website/content/workbooks/workbook-9.md
+++ b/website/content/workbooks/workbook-9.md
@@ -7,31 +7,28 @@ weight=4
 
 # Provisional start date: 6 May 2024
 
-## Study
-
-- [ ] [Distributed Systems: State](../../primers/distributed-software-systems-architecture/state)
-- [ ] [Troubleshooting Primer](../../primers/troubleshooting/)
-- [ ] [Linux Bash I](https://www.bogotobogo.com/Linux/linux_tips2_bash.php) & [Linux Bash II](https://www.bogotobogo.com/Linux/linux_tips2_bash.php) (There are other blog posts in the same series that could be useful to go through in spare time, would recommend running the commands that the blog post suggests for better understanding.)
-- [ ] PHP fastcgi - https://www.php.net/manual/en/install.fpm.php
-      Systemctl - https://www.freedesktop.org/software/systemd/man/systemctl.html and then https://www.redhat.com/sysadmin/linux-systemctl-manage-services
-- [ ] Nginx
-      https://nginx.org/en/docs/
-      https://nginx.org/en/docs/http/request_processing.html
-      https://www.nginx.com/resources/wiki/start/topics/examples/phpfcgi/
-
-## Projects
+## Consolidation
 
 - [ ] [Multiple servers](../../projects/multiple-servers) Revisit this project and deploy it with Docker and GH Actions
-- [ ] [Troubleshooting project #3](https://docs.google.com/document/d/1V6HEu_OcJ3MHH-aHzUfANf06VJa1rPcGHcpBwql7QLA/edit#heading=h.cjnguaxmynan) TOADD
 
-#### Optional (but recommended) software ops tutorials:
+## Managing state at scale
 
+- [ ] Read about [Distributed Systems: State](../../primers/distributed-software-systems-architecture/state)
 - [ ] Do this HashiCorp tutorial. It will give you hands-on experience with seeing health checks can be used to manage failure. https://learn.hashicorp.com/tutorials/consul/introduction-chaos-engineering?in=consul/resiliency
 - [ ] Demonstrate circuit breaking with this HashiCorp tutorial: https://learn.hashicorp.com/tutorials/consul/service-mesh-circuit-breaking?in=consul/resiliency
 - [ ] See different kinds of load-balancing algorithms in use with this HashiCorp tutorial: https://learn.hashicorp.com/tutorials/consul/load-balancing-envoy?in=consul/resiliency
 - [ ] Do this tutorial which demonstrates autoscaling with minikube (you will need to install minikube on your computer if you don’t have it). It will give you hands-on experience in configuring autoscaling, plus some exposure to Kubernetes configuration.  
-       You may need to run this command first: minikube addons enable metrics-server
+      You may need to run this command first: minikube addons enable metrics-server
       https://learndevops.novalagung.com/kubernetes-minikube-deployment-service-horizontal-autoscale.html
+
+## Command line familiarity
+
+- [ ] [Linux Bash I](https://www.bogotobogo.com/Linux/linux_tips2_bash.php) & [Linux Bash II](https://www.bogotobogo.com/Linux/linux_bash_2.php) (There are other blog posts in the same series that could be useful to go through in spare time, would recommend running the commands that the blog post suggests for better understanding.)
+
+## Troubleshooting
+
+- [ ] [Troubleshooting Primer](../../primers/troubleshooting/)
+- [ ] [Troubleshooting project #3](https://docs.google.com/document/d/1V6HEu_OcJ3MHH-aHzUfANf06VJa1rPcGHcpBwql7QLA/edit#heading=h.cjnguaxmynan) TOADD
 
 ## Product
 


### PR DESCRIPTION
This doesn't add the learning objectives and links between the tasks we'd like to add, but it's a start in improving the groupings.

Also, remove things from Sprint 3 which were moved to Sprint 1.

This is the start of https://github.com/CodeYourFuture/immersive-go-course/issues/194