### PR TITLE
fix 'Linux Bash II' link in Sprint 3 workbook

### DIFF
--- a/website/content/workbooks/workbook-9.md
+++ b/website/content/workbooks/workbook-9.md
@@ -11,7 +11,7 @@ weight=4
 
 - [ ] [Distributed Systems: State](../../primers/distributed-software-systems-architecture/state)
 - [ ] [Troubleshooting Primer](../../primers/troubleshooting/)
-- [ ] [Linux Bash I](https://www.bogotobogo.com/Linux/linux_tips2_bash.php) & [Linux Bash II](https://www.bogotobogo.com/Linux/linux_tips2_bash.php) (There are other blog posts in the same series that could be useful to go through in spare time, would recommend running the commands that the blog post suggests for better understanding.)
+- [ ] [Linux Bash I](https://www.bogotobogo.com/Linux/linux_tips2_bash.php) & [Linux Bash II](https://www.bogotobogo.com/Linux/linux_bash_2.php) (There are other blog posts in the same series that could be useful to go through in spare time, would recommend running the commands that the blog post suggests for better understanding.)
 - [ ] PHP fastcgi - https://www.php.net/manual/en/install.fpm.php
       Systemctl - https://www.freedesktop.org/software/systemd/man/systemctl.html and then https://www.redhat.com/sysadmin/linux-systemctl-manage-services
 - [ ] Nginx


### PR DESCRIPTION
Edit:

Issue was resolved in this PR: https://github.com/CodeYourFuture/immersive-go-course/pull/197

---

In: https://systems.codeyourfuture.io/workbooks/workbook-9/

The **Linux Bash II** link took you to **the same** place as the **Linux Bash I** link

This PR changes that so it takes you to the "**bash (Bourne Again Shell) II - 2018**" article (which i assume was the original intention)